### PR TITLE
Add support for xfce4-screensaver.

### DIFF
--- a/joystickwake
+++ b/joystickwake
@@ -344,6 +344,7 @@ DEFAULT_WAKERS = [
     ExecWaker('xscreensaver-command', '-deactivate', name="XScreenSaver"),
     ExecWaker('gnome-screensaver-command', '--deactivate', name="GNOME"),
     ExecWaker('mate-screensaver-command', '--poke', name="MATE"),
+    ExecWaker('xfce4-screensaver-command', '--poke', name="XFCE"),
     ]
 
 


### PR DESCRIPTION
Xfce4 Developers created xfce4-screensaver (forked from mate-screensaver.) in xfce 4.14.
This pr adds xfce4-screensaver as an waker.