### PR TITLE
Catch FileNotFoundError when trying to open the /dev/input files

### DIFF
--- a/joystickwake
+++ b/joystickwake
@@ -426,6 +426,9 @@ class JoystickWatcher:
         except PermissionError:
             self._log.error("permission denied on open %s", device.device_node)
             return
+        except FileNotFoundError:
+            self._log.error("file not found %s", device.device_node)
+            return
 
         # Now that we're sure we can use the device, close any old one.
         if olddevinfo:


### PR DESCRIPTION
The script crashes when there is no `/dev/input/js0` be it because there's no joystick or because the OS skipped js0 and went for js1.

If you configured your system to autorun the script and to revive it if it crashes (which is desirable) it will flood your system logs with crashes, making troubleshooting of other problems.